### PR TITLE
feat: allow dims after last foldable dim during list conversion

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Allow dims after last foldable dim during list conversion (e.g. embeddings)
+
 # v0.2.2
 
 - Github release :octocat:

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Unreleased
+# v0.3.0
 
 - Allow dims after last foldable dim during list conversion (e.g. embeddings)
 

--- a/foldedtensor/__init__.py
+++ b/foldedtensor/__init__.py
@@ -20,7 +20,7 @@ numpy_to_torch_dtype_dict = {
 
 from . import _C
 
-__version__ = "0.2.2"
+__version__ = "0.3.0"
 
 
 # noinspection PyMethodOverriding

--- a/foldedtensor/functions.cpp
+++ b/foldedtensor/functions.cpp
@@ -127,6 +127,12 @@ size_t flatten_py_list(
     bool next_is_foldable_dim = dim + 1 < data_dim_map.size();
 
     if (!py::isinstance<py::list>(nested_list[0])) {
+        if (dim < data_dim_map.size() - 1) {
+            throw py::value_error(
+                    "The provided data_dims have too many entries compared "
+                    "to the nesting of the input."
+            );
+        }
         operations.emplace_back(
                 current_indices,
                 total,
@@ -166,12 +172,13 @@ size_t flatten_py_list(
                 shape.push_back(0);
             }
 
+            shape[current_indices.size() - 1] = std::max(shape[current_indices.size() - 1], current_indices.back());
+
             if (is_data_dim) {
 
                 current_indices.pop_back();
                 current_indices.back() += 1;
             }
-            shape[current_indices.size() - 1] = std::max(shape[current_indices.size() - 1], current_indices.back());
 
             if (dim + 1 == data_dim_map.size()) {
                 total += 1;
@@ -180,9 +187,7 @@ size_t flatten_py_list(
     }
 
     shape[current_indices.size() - 1] = std::max(shape[current_indices.size() - 1], current_indices.back());
-    /*if (is_data_dim) {
-        // shape[data_dim_map[dim]] = std::max(shape[data_dim_map[dim]], current_indices.back());
-    }*/
+
     return total;
 }
 

--- a/tests/test_folded_tensor.py
+++ b/tests/test_folded_tensor.py
@@ -39,6 +39,41 @@ def test_as_folded_tensor_from_nested_list():
     assert ft.mask.dtype == torch.bool
 
 
+def test_embedding_from_nested_list():
+    ft = as_folded_tensor(
+        [
+            [[[1, 1, 1]], [], [], [], [[2, 2, 2], [3, 3, 3]]],
+            [[[4, 4, 4], [3, 3, 3]]],
+        ],
+        data_dims=("samples", "lines", "words"),
+        full_names=("samples", "lines", "words"),
+        dtype=torch.long,
+    )
+    assert ft.data.shape == (2, 5, 2, 3)
+    assert ft.lengths == [[2], [5, 1], [1, 0, 0, 0, 2, 2]]
+    assert ft.data_dims == (0, 1, 2)
+    assert ft.full_names == ("samples", "lines", "words")
+    assert (
+        ft.data[..., 0]
+        == torch.tensor(
+            [
+                [[1, 0], [0, 0], [0, 0], [0, 0], [2, 3]],
+                [[4, 3], [0, 0], [0, 0], [0, 0], [0, 0]],
+            ]
+        )
+    ).all()
+    assert (
+        ft.mask
+        == torch.tensor(
+            [
+                [[1, 0], [0, 0], [0, 0], [0, 0], [1, 1]],
+                [[1, 1], [0, 0], [0, 0], [0, 0], [0, 0]],
+            ]
+        ).bool()
+    ).all()
+    assert ft.mask.dtype == torch.bool
+
+
 def test_as_folded_tensor_from_tensor():
     ft = as_folded_tensor(
         torch.tensor(

--- a/tests/test_folded_tensor.py
+++ b/tests/test_folded_tensor.py
@@ -274,3 +274,38 @@ def test_list_args(ft):
     assert cat_ft.data.shape == (5, 32)
     refolded = cat_ft.refold("samples", "words")
     assert refolded.data.shape == (2, 3, 32)
+
+
+def test_too_deep():
+    with pytest.raises(ValueError) as excinfo:
+        as_folded_tensor(
+            [
+                [0, 1, 2],
+                [3, 4],
+            ],
+            full_names=("sample", "line", "token"),
+            data_dims=("sample", "line", "token"),
+            dtype=torch.long,
+        )
+    assert "nesting" in str(excinfo.value)
+
+
+def test_pad_embedding():
+    ft = as_folded_tensor(
+        [
+            [0, 1, 2],
+            [3, 4],
+        ],
+        full_names=("token",),
+        data_dims=("token",),
+        dtype=torch.long,
+    )
+    assert (
+        ft.data
+        == torch.tensor(
+            [
+                [0, 1, 2],
+                [3, 4, 0],
+            ]
+        )
+    ).all()


### PR DESCRIPTION
## Description

This PR enables the initial conversion of nested lists that contain dimensions after the last foldable dimension.
This can be useful for embeddings or multi feature tensors, such as box coordinates.

For instance, converting nested lists of words into a tensor, each word represented by 3 ints:

```python
ft = as_folded_tensor(
    [
        [[[1, 1, 1]], [], [], [], [[2, 2, 2], [3, 3, 3]]],
        [[[4, 4, 4], [3, 3, 3]]],
    ],
    data_dims=("samples", "lines", "words"),
    full_names=("samples", "lines", "words"),
    dtype=torch.long,
)
assert ft.data.shape == (2, 5, 2, 3)
assert ft.lengths == [[2], [5, 1], [1, 0, 0, 0, 2, 2]]
assert ft.data_dims == (0, 1, 2)
assert ft.full_names == ("samples", "lines", "words")
```

Before this PR, this would have required creating 3 tensors and stacking them along the last dimensions afterwards.

<!--- Describe the changes. -->

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
