### PR TITLE
Enable sharing in multiprocessing + cuda context

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,4 +10,4 @@
 
 - [ ] If this PR is a bug fix, the bug is documented in the test suite.
 - [ ] Changes were documented in the changelog (pending section).
-- [ ] If necessary, changes were made to the documentation (eg new pipeline).
+- [ ] If necessary, changes were made to the documentation.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Enable sharing FoldedTensor instances in a multiprocessing + cuda context by autocloning the indexer before fork-pickling an instance
+
 # v0.3.0
 
 - Allow dims after last foldable dim during list conversion (e.g. embeddings)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import multiprocessing
+
+import pytest
+
+
+# This is necessary for CUDA to work properly in test_multiprocessing.py
+@pytest.fixture(scope="session", autouse=True)
+def mp_spawn():
+    multiprocessing.set_start_method("spawn")

--- a/tests/test_folded_tensor.py
+++ b/tests/test_folded_tensor.py
@@ -13,6 +13,7 @@ def test_as_folded_tensor_from_nested_list():
         data_dims=("samples", "lines", "words"),
         full_names=("samples", "lines", "words"),
         dtype=torch.long,
+        device=torch.device("cpu"),
     )
     assert ft.data.shape == (2, 5, 2)
     assert ft.lengths == [[2], [5, 1], [1, 0, 0, 0, 2, 2]]
@@ -309,3 +310,25 @@ def test_pad_embedding():
             ]
         )
     ).all()
+
+
+def test_as_tensor(ft):
+    tensor = ft.as_tensor()
+    assert type(tensor) == torch.Tensor
+    assert tensor.shape == (2, 5, 2)
+    assert tensor.storage().data_ptr() == ft.storage().data_ptr()
+
+
+def test_clone(ft):
+    assert isinstance(ft.mask, torch.Tensor)
+    cloned = ft.clone()
+    assert cloned.storage().data_ptr() != ft.storage().data_ptr()
+    assert cloned.indexer.storage().data_ptr() != ft.indexer.storage().data_ptr()
+
+
+def test_share_memory(ft):
+    assert isinstance(ft.mask, torch.Tensor)
+    cloned = ft.share_memory_()
+    assert cloned.is_shared()
+    assert cloned.indexer.is_shared()
+    assert cloned.mask.is_shared()

--- a/tests/test_multiprocessing.py
+++ b/tests/test_multiprocessing.py
@@ -1,0 +1,79 @@
+from multiprocessing.reduction import ForkingPickler
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+
+from foldedtensor import as_folded_tensor
+
+
+def workerB(X, Y, done, result, device):
+    print("Started B, waiting for X", device, flush=True)
+    tensor = X.get()
+    assert tensor.is_shared()
+    assert tensor.indexer.is_shared()
+    new_tensor = tensor + 1
+    assert new_tensor.indexer is tensor.indexer
+    print("B put back tensor in Y", flush=True)
+    Y.put(new_tensor)
+    del tensor
+    done.get()
+    del new_tensor
+    result.put(True)
+
+
+def workerA(X, Y, done, result, device):
+    print("Started A", device, flush=True)
+    t = as_folded_tensor(
+        data=[[4, 3]],
+        data_dims=("samples", "lines"),
+        full_names=("samples", "lines"),
+        dtype=torch.long,
+    ).to(device)
+    X.put(t)
+    print("A waiting for Y", flush=True)
+    Y.get()
+    print("A received from Y", flush=True)
+    done.put(True)
+    result.put(True)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_share_device(device: str):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    X = mp.Queue()
+    Y = mp.Queue()
+    done = mp.Queue()
+    result = mp.Queue()
+    a = mp.Process(target=workerA, args=(X, Y, done, result, device))
+    b = mp.Process(target=workerB, args=(X, Y, done, result, device))
+    a.start()
+    b.start()
+    a.join()
+    b.join()
+
+    assert result.get()
+    assert result.get()
+    print("Done", flush=True)
+
+    X.close()
+    Y.close()
+    done.close()
+    result.close()
+    X.join_thread()
+    Y.join_thread()
+    done.join_thread()
+    result.join_thread()
+
+
+def test_forking_pickler():
+    ft = as_folded_tensor(
+        [
+            [4, 3],
+        ],
+        data_dims=("samples", "lines"),
+        full_names=("samples", "lines"),
+        dtype=torch.long,
+    ).share_memory_()
+    print(ForkingPickler.dumps(ft))


### PR DESCRIPTION
## Description

Pytorch prevents a tensor that was received from another process to be re-shared. When using `with_data`, a new FoldedTensor is returned but the same mask and indexer are kept. Sharing this tensor in a mp context can cause issues if the mask / indexer are on a cuda device.

This PR register our class in pytorch's ForkingPickler to clone the indexer matrix and unset the mask just before sending a FoldedTensor, and prevent an error.

However, re-sending a received tensor is still not possible : the user can still `.clone` the foldedtensor explicitly to allow this.

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation (eg new pipeline).
