### PR TITLE
Handle empty inputs and show better errors for inputs with varying deepness

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# v0.3.3
+
+- Handle empty inputs (e.g. `as_folded_tensor([[[], []], [[]]])`) by returning an empty tensor
+- Correctly bubble errors when converting inputs with varying deepness (e.g. `as_folded_tensor([1, [2, 3]])`)
+
 # v0.3.2
 
 - Allow to use `as_folded_tensor` with no args, as a simple padding function

--- a/tests/test_folded_tensor.py
+++ b/tests/test_folded_tensor.py
@@ -367,3 +367,40 @@ def test_share_memory(ft):
     assert cloned.is_shared()
     assert cloned.indexer.is_shared()
     assert cloned.mask.is_shared()
+
+
+def test_empty_sequence():
+    ft = as_folded_tensor(
+        [
+            [[], [], []],
+            [[], []],
+        ],
+        dtype=torch.float,
+    )
+    assert ft.shape == (2, 3, 0)
+
+
+def test_imbalanced_sequence_1():
+    with pytest.raises(ValueError) as e:
+        as_folded_tensor(
+            [
+                3,
+                [0, 1, 2],
+            ],
+            dtype=torch.float,
+        )
+
+    assert "setting an array element with a sequence." in str(e.value)
+
+
+def test_imbalanced_sequence_2():
+    with pytest.raises(TypeError) as e:
+        as_folded_tensor(
+            [
+                [0, 1, 2],
+                3,
+            ],
+            dtype=torch.float,
+        )
+
+    assert "'int' object is not iterable" in str(e.value)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- Handle empty inputs (e.g. `as_folded_tensor([[[], []], [[]]])`) by returning an empty tensor
- Correctly bubble errors when converting inputs with varying deepness (e.g. `as_folded_tensor([1, [2, 3]])`)

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
