### PR TITLE
Bump version to 0.3.3

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.13.1
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
 

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -9,7 +9,7 @@ and working with nested lists and tensors.
 
 Versions:
 - `torch.__version__ == '2.0.1'`
-- `foldedtensor.__version__ == '0.3.2'`
+- `foldedtensor.__version__ == '0.3.3'`
 
 
 ## Case 1 (pad variable lengths nested list)

--- a/foldedtensor/__init__.py
+++ b/foldedtensor/__init__.py
@@ -21,7 +21,7 @@ np_to_torch_dtype = {
 
 from . import _C
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 
 # noinspection PyMethodOverriding


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- Handle empty inputs (e.g. `as_folded_tensor([[[], []], [[]]])`) by returning an empty tensor
- Correctly bubble errors when converting inputs with varying deepness (e.g. `as_folded_tensor([1, [2, 3]])`)

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
