### PR TITLE
fix: use untyped storage to stop warning

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix `storage` torch warning
+
 ## v0.3.5
 
 - Support hashing the `folded_tensor.length` field (via a UserList), which is convenient for caching


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- Fix `storage` torch warning

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
