### PR TITLE
v0.4.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
             arch: x86_64
           - os: macos-latest
             arch: arm64
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             arch: '*'  # unused
           - os: windows-latest
             arch: '*'  # unused
@@ -26,39 +26,45 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.23.1
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
 
-      - uses: actions/upload-artifact@v3
+      - name: List wheels
+        run: ls -l ./wheelhouse
+
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-${{ matrix.os }}-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
 
   build_sdist:
     name: Build source distribution
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
 
       - name: Build sdist
         run: pipx run build --sdist
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
+          name: artifact-${{ matrix.os }}-${{ matrix.arch }}
           path: dist/*.tar.gz
 
   PyPI:
     name: Upload to PyPI
 
     needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       id-token: write
 
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
-        name: artifact
+        name: artifact*
         path: dist
+        merge-multiple: true
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -32,13 +32,9 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.5
+        uses: pypa/cibuildwheel@v2.23.2
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: ./wheelhouse/*.whl
 
   build_sdist:
     name: Build source distribution
@@ -48,7 +44,3 @@ jobs:
 
       - name: Build sdist
         run: pipx run build --sdist
-
-      - uses: actions/upload-artifact@v3
-        with:
-          path: dist/*.tar.gz

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## Unreleased
+## v0.4.0
 
 - Fix `storage` torch warning
+- Support numpy 2.0 and Python 3.11, 3.12 and 3.13 🎉
 
 ## v0.3.5
 

--- a/foldedtensor/__init__.py
+++ b/foldedtensor/__init__.py
@@ -46,7 +46,7 @@ try:
 except AttributeError:
     DisableTorchFunctionSubclass = torch._C.DisableTorchFunction
 
-__version__ = "0.3.6"
+__version__ = "0.4.0"
 
 
 class FoldedTensorLengths(UserList):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

## Description

- Fix `storage` torch warning
- Support numpy 2.0 and Python 3.11, 3.12 and 3.13 🎉

## Checklist

<!--- Every item must be checked before the PR is merged. [] -> [x] -->

- [x] If this PR is a bug fix, the bug is documented in the test suite.
- [x] Changes were documented in the changelog (pending section).
- [x] If necessary, changes were made to the documentation.
